### PR TITLE
Fix nested project pull scope when ancestor .waylog exists

### DIFF
--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -10,7 +10,8 @@ pub async fn handle_pull(
     provider_name: Option<String>,
     force: bool,
     verbose: bool,
-    project_path: PathBuf,
+    tracking_root: PathBuf,
+    target_project_path: PathBuf,
     output: &mut Output,
 ) -> Result<()> {
     // 1. Validate provider first (before any other operations)
@@ -26,7 +27,7 @@ pub async fn handle_pull(
         }
     }
 
-    output.pull_start(&project_path)?;
+    output.pull_start(&target_project_path)?;
 
     // Filter providers
     let providers_to_sync = if let Some(name) = provider_name {
@@ -51,10 +52,11 @@ pub async fn handle_pull(
 
         // Create session tracker and synchronizer
         let tracker =
-            Arc::new(session::SessionTracker::new(project_path.clone(), provider.clone()).await?);
+            Arc::new(session::SessionTracker::new(tracking_root.clone(), provider.clone()).await?);
         let synchronizer = synchronizer::Synchronizer::new(
             provider.clone(),
-            project_path.clone(),
+            tracking_root.clone(),
+            target_project_path.clone(),
             tracker.clone(),
         );
 

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -13,7 +13,8 @@ use tokio::task::JoinHandle;
 pub async fn handle_run(
     agent: Option<String>,
     args: Vec<String>,
-    project_path: PathBuf,
+    tracking_root: PathBuf,
+    target_project_path: PathBuf,
     output: &mut Output,
 ) -> Result<()> {
     let agent_name = match agent {
@@ -43,32 +44,41 @@ pub async fn handle_run(
     }
 
     // Now run_agent can focus on execution without validation
-    run_agent(args, project_path, provider).await?;
+    run_agent(args, tracking_root, target_project_path, provider).await?;
 
     Ok(())
 }
 
 async fn run_agent(
     args: Vec<String>,
-    project_path: PathBuf,
+    tracking_root: PathBuf,
+    target_project_path: PathBuf,
     provider: Arc<dyn providers::base::Provider>,
 ) -> Result<()> {
     // Provider is already validated in handle_run, so we can focus on execution
-    tracing::info!("Starting {} in {}", provider.name(), project_path.display());
+    tracing::info!(
+        "Starting {} in {}",
+        provider.name(),
+        target_project_path.display()
+    );
 
     // Ensure .waylog/history directory exists
-    let waylog_dir = utils::path::get_waylog_dir(&project_path);
+    let waylog_dir = utils::path::get_waylog_dir(&tracking_root);
     utils::path::ensure_dir_exists(&waylog_dir)?;
 
     tracing::info!("Chat history will be saved to: {}", waylog_dir.display());
 
     // Create session tracker
     let tracker =
-        Arc::new(session::SessionTracker::new(project_path.clone(), provider.clone()).await?);
+        Arc::new(session::SessionTracker::new(tracking_root.clone(), provider.clone()).await?);
 
     // Create file watcher
-    let watcher =
-        watcher::FileWatcher::new(provider.clone(), project_path.clone(), tracker.clone());
+    let watcher = watcher::FileWatcher::new(
+        provider.clone(),
+        tracking_root.clone(),
+        target_project_path.clone(),
+        tracker.clone(),
+    );
 
     // Start file watcher in background
     let watcher_handle: JoinHandle<()> = tokio::spawn(async move {
@@ -153,7 +163,7 @@ async fn run_agent(
                     &mut child,
                     &tracker,
                     &provider,
-                    &project_path,
+                    &target_project_path,
                     &waylog_dir,
                     Some(status),
                 )
@@ -177,7 +187,7 @@ async fn run_agent(
                     &mut child,
                     &tracker,
                     &provider,
-                    &project_path,
+                    &target_project_path,
                     &waylog_dir,
                     Some(status),
                 )
@@ -194,7 +204,7 @@ async fn run_agent(
                     &mut child,
                     &tracker,
                     &provider,
-                    &project_path,
+                    &target_project_path,
                     &waylog_dir,
                     Some(status),
                 )
@@ -227,7 +237,7 @@ async fn run_agent(
                         &mut child,
                         &tracker,
                         &provider,
-                        &project_path,
+                        &target_project_path,
                         &waylog_dir,
                         Some(status),
                     )
@@ -247,7 +257,7 @@ async fn run_agent(
                     &mut child,
                     &tracker,
                     &provider,
-                    &project_path,
+                    &target_project_path,
                     &waylog_dir,
                     Some(status),
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ async fn main() {
 
         // 1. Resolve project root directory
         let (project_root, is_new_project) = init::resolve_project_root(&cli.command, &mut output)?;
+        let current_dir = std::env::current_dir()?;
 
         // 2. Setup logging (only creates log file if verbose)
         init::setup_logging(&project_root, cli.verbose, cli.quiet)?;
@@ -67,10 +68,18 @@ async fn main() {
         // 4. Dispatch command
         match cli.command {
             Commands::Run { agent, args } => {
-                handle_run(agent, args, project_root, &mut output).await?;
+                handle_run(agent, args, project_root, current_dir, &mut output).await?;
             }
             Commands::Pull { provider, force } => {
-                handle_pull(provider, force, cli.verbose, project_root, &mut output).await?;
+                handle_pull(
+                    provider,
+                    force,
+                    cli.verbose,
+                    project_root,
+                    current_dir,
+                    &mut output,
+                )
+                .await?;
             }
         }
 

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -233,20 +233,7 @@ impl CodexProvider {
                         .trim_end_matches('\\')
                         .to_string();
 
-                    // Direct match
-                    if session_cwd == target_str {
-                        return Ok(true);
-                    }
-
-                    // Subdirectory match (safety: ensure we don't match root by accident)
-                    if (target_str.starts_with(&session_cwd) && session_cwd.len() > 1)
-                        || (session_cwd.starts_with(&target_str) && target_str.len() > 1)
-                    {
-                        return Ok(true);
-                    }
-
-                    // If we found a CWD but it definitely doesn't match, we can stop
-                    return Ok(false);
+                    return Ok(session_cwd == target_str);
                 }
             }
         }
@@ -327,4 +314,37 @@ struct CodexContent {
     #[allow(dead_code)]
     content_type: String,
     text: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn session_meta_line(cwd: &str) -> String {
+        format!(
+            r#"{{"type":"session_meta","timestamp":"2026-04-01T00:00:00Z","payload":{{"cwd":"{}"}}}}"#,
+            cwd
+        )
+    }
+
+    #[tokio::test]
+    async fn probe_project_path_requires_exact_cwd_match() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("session.jsonl");
+        tokio::fs::write(&file_path, session_meta_line("/home/cody"))
+            .await
+            .unwrap();
+
+        let provider = CodexProvider::new();
+
+        assert!(provider
+            .probe_project_path(&file_path, Path::new("/home/cody"))
+            .await
+            .unwrap());
+        assert!(!provider
+            .probe_project_path(&file_path, Path::new("/home/cody/trade-bot"))
+            .await
+            .unwrap());
+    }
 }

--- a/src/synchronizer.rs
+++ b/src/synchronizer.rs
@@ -10,7 +10,8 @@ use tracing::debug;
 /// Shared synchronization logic for both watcher and batch sync
 pub struct Synchronizer {
     provider: Arc<dyn Provider>,
-    project_dir: PathBuf,
+    tracking_root: PathBuf,
+    target_project_dir: PathBuf,
     tracker: Arc<SessionTracker>,
 }
 
@@ -25,12 +26,14 @@ pub enum SyncStatus {
 impl Synchronizer {
     pub fn new(
         provider: Arc<dyn Provider>,
-        project_dir: PathBuf,
+        tracking_root: PathBuf,
+        target_project_dir: PathBuf,
         tracker: Arc<SessionTracker>,
     ) -> Self {
         Self {
             provider,
-            project_dir,
+            tracking_root,
+            target_project_dir,
             tracker,
         }
     }
@@ -38,7 +41,10 @@ impl Synchronizer {
     /// Sync all available sessions from the provider
     /// Returns stats: (Synced, UpToDate, Skipped, Failed)
     pub async fn sync_all(&self, force: bool) -> Result<Vec<(PathBuf, SyncStatus)>> {
-        let sessions = self.provider.get_all_sessions(&self.project_dir).await?;
+        let sessions = self
+            .provider
+            .get_all_sessions(&self.target_project_dir)
+            .await?;
         let mut results = Vec::new();
 
         for session_path in sessions {
@@ -80,7 +86,7 @@ impl Synchronizer {
 
                 let timestamp = session.started_at.format("%Y-%m-%d_%H-%M-%SZ");
                 let filename = format!("{}-{}-{}.md", timestamp, self.provider.name(), slug);
-                let path = path::get_waylog_dir(&self.project_dir).join(filename);
+                let path = path::get_waylog_dir(&self.tracking_root).join(filename);
 
                 (path, 0)
             };
@@ -138,5 +144,127 @@ impl Synchronizer {
         Ok(SyncStatus::Synced {
             new_messages: new_messages.len(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::base::{
+        ChatMessage, ChatSession, MessageMetadata, MessageRole, Provider,
+    };
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use std::path::Path;
+    use tempfile::TempDir;
+    use tokio::sync::Mutex;
+
+    struct MockProvider {
+        session_path: PathBuf,
+        session: ChatSession,
+        queried_projects: Arc<Mutex<Vec<PathBuf>>>,
+    }
+
+    #[async_trait]
+    impl Provider for MockProvider {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        fn data_dir(&self) -> Result<PathBuf> {
+            Ok(std::env::temp_dir())
+        }
+
+        fn session_dir(&self, _project_path: &Path) -> Result<PathBuf> {
+            Ok(std::env::temp_dir())
+        }
+
+        async fn find_latest_session(&self, _project_path: &Path) -> Result<Option<PathBuf>> {
+            Ok(Some(self.session_path.clone()))
+        }
+
+        async fn parse_session(&self, file_path: &Path) -> Result<ChatSession> {
+            assert_eq!(file_path, self.session_path);
+            Ok(self.session.clone())
+        }
+
+        async fn get_all_sessions(&self, project_path: &Path) -> Result<Vec<PathBuf>> {
+            self.queried_projects
+                .lock()
+                .await
+                .push(project_path.to_path_buf());
+            Ok(vec![self.session_path.clone()])
+        }
+
+        fn is_installed(&self) -> bool {
+            true
+        }
+
+        fn command(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_all_uses_target_project_for_lookup_and_tracking_root_for_output() {
+        let temp_dir = TempDir::new().unwrap();
+        let tracking_root = temp_dir.path().join("tracking-root");
+        let target_project = temp_dir.path().join("tracking-root").join("nested-project");
+        let session_path = temp_dir.path().join("session.jsonl");
+
+        tokio::fs::create_dir_all(&tracking_root).await.unwrap();
+        tokio::fs::create_dir_all(&target_project).await.unwrap();
+
+        let now = Utc::now();
+        let session = ChatSession {
+            session_id: "session-1".to_string(),
+            provider: "mock".to_string(),
+            project_path: target_project.clone(),
+            started_at: now,
+            updated_at: now,
+            messages: vec![ChatMessage {
+                id: "msg-1".to_string(),
+                timestamp: now,
+                role: MessageRole::User,
+                content: "Nested project session".to_string(),
+                metadata: MessageMetadata::default(),
+            }],
+        };
+
+        let queried_projects = Arc::new(Mutex::new(Vec::new()));
+        let provider = Arc::new(MockProvider {
+            session_path: session_path.clone(),
+            session,
+            queried_projects: queried_projects.clone(),
+        });
+
+        let tracker = Arc::new(
+            SessionTracker::new(tracking_root.clone(), provider.clone())
+                .await
+                .unwrap(),
+        );
+        let synchronizer = Synchronizer::new(
+            provider,
+            tracking_root.clone(),
+            target_project.clone(),
+            tracker,
+        );
+
+        let results = synchronizer.sync_all(false).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, session_path);
+        assert!(matches!(
+            results[0].1,
+            SyncStatus::Synced { new_messages: 1 }
+        ));
+
+        let queried = queried_projects.lock().await;
+        assert_eq!(queried.as_slice(), &[target_project]);
+        drop(queried);
+
+        let history_dir = path::get_waylog_dir(&tracking_root);
+        let mut entries = tokio::fs::read_dir(&history_dir).await.unwrap();
+        let markdown = entries.next_entry().await.unwrap().unwrap().path();
+        assert!(markdown.starts_with(&history_dir));
     }
 }

--- a/src/watcher/file_watcher.rs
+++ b/src/watcher/file_watcher.rs
@@ -14,22 +14,27 @@ const SYNC_INTERVAL_SECS: u64 = 30;
 /// Periodic sync watcher (simplified - no file watching)
 pub struct FileWatcher {
     provider: Arc<dyn Provider>,
-    project_dir: PathBuf,
+    target_project_dir: PathBuf,
     synchronizer: Synchronizer,
 }
 
 impl FileWatcher {
     pub fn new(
         provider: Arc<dyn Provider>,
-        project_dir: PathBuf,
+        tracking_root: PathBuf,
+        target_project_dir: PathBuf,
         tracker: Arc<SessionTracker>,
     ) -> Self {
-        let synchronizer =
-            Synchronizer::new(provider.clone(), project_dir.clone(), tracker.clone());
+        let synchronizer = Synchronizer::new(
+            provider.clone(),
+            tracking_root,
+            target_project_dir.clone(),
+            tracker.clone(),
+        );
 
         Self {
             provider,
-            project_dir,
+            target_project_dir,
             synchronizer,
         }
     }
@@ -55,7 +60,11 @@ impl FileWatcher {
     /// Sync only the latest session
     async fn sync_latest(&self) -> Result<()> {
         // Find the latest session file
-        let session_file = match self.provider.find_latest_session(&self.project_dir).await? {
+        let session_file = match self
+            .provider
+            .find_latest_session(&self.target_project_dir)
+            .await?
+        {
             Some(file) => file,
             None => {
                 debug!("No session file found");


### PR DESCRIPTION
## Background

When an ancestor directory already contains a `.waylog` folder, `waylog pull` currently resolves that ancestor as the project root and reuses it both as:

- the tracking destination
- the provider lookup scope

That breaks nested projects. For example, running `waylog pull` from `/home/cody/trade-bot` while `/home/cody/.waylog` exists causes WayLog to query Claude and Codex sessions for `/home/cody` instead of `/home/cody/trade-bot`.

This is the behavior reported in #19.

## Goal

Preserve the existing storage behavior while making provider lookup use the actual directory where the user invoked the command.

## Changes

- thread `tracking_root` and `target_project_path` separately through `main`, `pull`, `run`, the watcher, and the synchronizer
- keep writing markdown into the resolved tracking root as before
- use the current working directory as the provider lookup scope
- tighten Codex path matching to exact `cwd` equality so parent sessions do not leak into nested project pulls
- add regression coverage for nested project lookup and Codex exact path matching

## Result

- running `waylog pull` in a nested directory now fetches sessions for that nested directory correctly
- if an ancestor `.waylog` already exists, output still goes into that existing tracking root
- if no tracked ancestor exists, WayLog still initializes in the current directory

Closes #19.
